### PR TITLE
#103 - Exportar em massa (PDF)

### DIFF
--- a/delibera_curtir.php
+++ b/delibera_curtir.php
@@ -130,7 +130,7 @@ function delibera_get_quem_curtiu($ID, $type = 'pauta', $return = 'array')
 				foreach ($curtiuem as $curtiu)
 				{
 					if (strlen($ret) > 0) $ret .= ", ";
-					$ret .= (($curtiu['user'] == false || $curtiu['user'] == 0) ? $curtiu['ip'] : get_author_name($curtiu['user']));
+					$ret .= (($curtiu['user'] == false || $curtiu['user'] == 0) ? $curtiu['ip'] : get_the_author_meta('display_name', $curtiu['user']));
 				}
 			}
 			return $ret;

--- a/print/print-posts.php
+++ b/print/print-posts.php
@@ -46,7 +46,6 @@
 					<p id="BlogTitle"><?php the_title(); ?></p>
 					<p id="BlogDate"><?php _e('Postado por', 'delibera'); ?> <u><?php the_author(); ?></u> <?php _e('em', 'delibera'); ?> <?php the_time(sprintf(__('%s @ %s', 'delibera'), get_option('date_format'), get_option('time_format'))); ?> <?php _e('na', 'delibera'); ?> <?php print_categories('<u>', '</u>'); ?> | <u><a href='#comments_controls'><?php print_comments_number(); ?></a></u></p>
 					<div id="BlogContent"><?php print_content(); ?></div>
-			<?php endwhile; ?>
 			<hr class="Divider" style="text-align: center;" />
 			<?php if(print_can('comments')): ?>
 				<?php comments_template(); ?>
@@ -55,7 +54,8 @@
 			<p><?php _e('URL da pauta', 'delibera'); ?>: <strong dir="ltr"><?php the_permalink(); ?></strong></p>
 			<?php if(print_can('links')): ?>
 				<p><?php print_links(); ?></p>
-			<?php endif; ?>
+			<?php endif;
+			endwhile; ?>
 			<p style="text-align: <?php echo ('rtl' == $text_direction) ? 'left' : 'right'; ?>;" id="print-link"><?php _e('Click', 'delibera'); ?> <a href="#Print" onclick="window.print(); return false;" title="<?php _e('Click aqui para imprimir.', 'delibera'); ?>"><?php _e('aqui', 'delibera'); ?></a> <?php _e('para imprimir.', 'delibera'); ?></p>
 		<?php else: ?>
 				<p><?php _e('Não há pautas relacionadas a esse critério.', 'delibera'); ?></p>

--- a/print/print.php
+++ b/print/print.php
@@ -31,6 +31,9 @@ remove_filter('comments_array', 'delibera_get_comments_filter');
 
 define('PRINT', true);
 
+global $withcomments;
+$withcomments = true;
+
 ### Load Print Post/Page Template
 if(file_exists(TEMPLATEPATH.'/print-posts.php')) {
 	include(TEMPLATEPATH.'/print-posts.php');

--- a/print/wp-print.php
+++ b/print/wp-print.php
@@ -32,6 +32,7 @@ add_filter('query_vars', 'print_variables');
 function print_variables($public_query_vars) {
 	$public_query_vars[] = 'delibera_print';
 	$public_query_vars[] = 'delibera_printpage';
+    $public_query_vars[] = 'number-options';
 	return $public_query_vars;
 }
 
@@ -40,6 +41,9 @@ function delibera_print()
 {
 	if(intval(get_query_var('delibera_print')) == 1 || intval(get_query_var('delibera_printpage')) == 1)
 	{
+        global $wp_query;
+        $wp_query->set('posts_per_page', get_query_var('number-options'));
+        query_posts($wp_query->query_vars);
 		include(WP_PLUGIN_DIR.'/delibera/print/print.php');
 		exit();
 	}

--- a/print/wp-print.php
+++ b/print/wp-print.php
@@ -49,6 +49,10 @@ add_action('template_redirect', 'delibera_print', 5);
 ### Function: Print Content
 function print_content($display = true) {
 	global $links_text, $link_number, $max_link_number, $matched_links,  $pages, $multipage, $numpages, $post;
+    if (!isset($link_text) && isset($link_url)) {
+        $link_text = $link_url;
+    }
+
 	if (!isset($matched_links)) {
 		$matched_links = array();
 	}
@@ -131,6 +135,10 @@ function print_categories($before = '', $after = '', $parents = '')
 ### Function: Print Comments Content
 function print_comments_content($display = true) {
 	global $links_text, $link_number, $max_link_number, $matched_links;
+    if (!isset($link_text) && isset($link_url)) {
+        $link_text = $link_url;
+    }
+
 	if (!isset($matched_links)) {
 		$matched_links = array();
 	}


### PR DESCRIPTION
Exportar pautas e comentários em massa, no formato PDF.
- Permite a passagem do parâmetro 'number-options' (na url) com o número de pautas que se deseja imprimir em PDF.
  FIX pensandoodireito/participacao-sitebase#103
## ANTEÇÃO

> Antes de aceitar este pull-request é preciso aplicar as modificações do pull-request relativo à "**issue60**".
> Para tanto, caso o pull-request tenha sido aceito no repositório oficial do delibera, é preciso sincronizar o master deste repositório com o original,
> Caso o pull-request não tenha sido aceito, é preciso aplicar aquele "patch" neste repositório antes de se aceitar este pull-request.

Pull-Request em questão no repositório oficial:
https://github.com/ethymos/delibera/pull/41
